### PR TITLE
change callbacks to use node function signature (error, data)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -36,11 +36,14 @@ module.exports = function(content) {
 
     function ajax(url, callback) {
         var xhr = new XMLHttpRequest();
-        xhr.onload = function(e) {
-            var buffer = xhr.response; // not responseText
-            var result = NumpyParser.fromArrayBuffer(buffer);
-            callback(result);
+        xhr.onload = function(evt) {
+          var buffer = xhr.response; // not responseText
+          var result = NumpyParser.fromArrayBuffer(buffer);
+          callback(null, result);
         };
+        xhr.onerror = function(evt) {
+          callback(new Error("numpy-parser failed to fetch: " + url))
+        }
         xhr.open("GET", url, true);
         xhr.responseType = "arraybuffer";
         xhr.send(null);
@@ -48,9 +51,10 @@ module.exports = function(content) {
 
     module.exports = {
       load: function(callback) {
-        ajax("${outputPath}", function(data) {
+        ajax("${outputPath}", function(error, data) {
+          if(error) return callback(error);
           const result = NDArray(data.data, data.shape);
-          callback(result);
+          callback(error, result);
         });
       }
     };


### PR DESCRIPTION
This brings the loader callback in line with the node convention of expecting an error as the first argument to a callback. It will also alert people if there is an error trying to load the file as well.